### PR TITLE
Modified transferGopay and base requests

### DIFF
--- a/src/base-request.js
+++ b/src/base-request.js
@@ -19,6 +19,7 @@ module.exports = {
             json: true
         };
 
+        opt.headers = extend(opt.headers, options.headers)
         options = extend(options, opt);
 
         request(options, callback);

--- a/src/payment.js
+++ b/src/payment.js
@@ -30,7 +30,7 @@ module.exports = {
 
         request._request(options, '/wallet/qr-code', callback);
     },
-    transferGoPay: function (qrId, amount, description, callback) {
+    transferGoPay: function (qrId, amount, description, pinCode, callback) {
         var options = {
             method: 'POST',
             body: {
@@ -38,8 +38,10 @@ module.exports = {
                 amount: amount,
                 description: description
             },
+            headers: {
+                pin: pinCode
+            }
         };
-
-        request._request(options, '/fund/transfer', callback);
+        request._request(options, '/v2/fund/transfer', callback);
     }
 };


### PR DESCRIPTION
Apparently the API for transfer gopay is updated. Now requires you use a pin code and and then send the pin in the requests headers. And also, the API endpoint is changed.